### PR TITLE
Change exit status for failed connections

### DIFF
--- a/ssh-ping
+++ b/ssh-ping
@@ -155,8 +155,8 @@ function print_statistics() {
     statistics_crit+="${RED}${requests_received}${RESET} ${WHITE}requests received${RESET}, "
     statistics_crit+="${RED}${requests_loss}%${RESET} ${WHITE}request loss${RESET}"
 
-    [[ ${requests_loss} -eq 100 ]] &&  echo -e "${statistics_crit}" && exit
-    [[ ${requests_loss} -gt   1 ]] &&  echo -e "${statistics_warn}" && exit
+    [[ ${requests_loss} -eq 100 ]] &&  echo -e "${statistics_crit}" && exit 1
+    [[ ${requests_loss} -gt   1 ]] &&  echo -e "${statistics_warn}" && exit 1
     [[ ${requests_loss} -eq   0 ]] &&  echo -e "${statistics_ok}"   && exit
 
 }


### PR DESCRIPTION
Change exit status to `1` for one or more failed pings. 

Useful for shell scripting:

__Old way:__
```sh
ssh-ping -q -c 1 my_website | grep 100 >/dev/null || ...
```
__New way:__
```sh
ssh-ping -q -c 1 my_website >/dev/null || ...
```