### PR TITLE
Use [[:space:]] instead of \s for portability

### DIFF
--- a/ssh-facts
+++ b/ssh-facts
@@ -49,7 +49,7 @@ if [[ -z $1 || $1 == "--help" ]]; then
     exit 1
 fi
 
-ssh "$@" 'bash -s' 2>/dev/null <<'END' | sed 's/\s*=\s*/=/'
+ssh "$@" 'bash -s' 2>/dev/null <<'END' | sed 's/[[:space:]]*=[[:space:]]*/=/'
 
 function _os() {
 


### PR DESCRIPTION
E.g., FreeBSD sed does not support \s,
which leads to the following error:

    sed: 1: "s/\s*=\s*/=/": RE error: trailing backslash (\)